### PR TITLE
Build system tweaks

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -60,9 +60,6 @@ jobs:
       name: Set up vcpkg for Unix
       run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
     
-    - name: Install dependencies
-      run: ${{ env.VCPKG_ROOT }}/vcpkg install protobuf protobuf:${{ matrix.triplet }}
-    
     - name: Configure CMake
       run: cmake -S "${{github.workspace}}" -B "${{env.CMAKE_BUILD_DIR}}"
       

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ find_library(OPENVR_LIB openvr_api HINTS "${CMAKE_CURRENT_SOURCE_DIR}/libraries/
 # Installation:
 # Please refer to this readme to install protobuf in your system: https://github.com/protocolbuffers/protobuf/blob/master/src/README.md
 # WARNING: CLang has an arror building protobuf messages, use MSVC 2019
-INCLUDE(FindProtobuf)
-find_package(protobuf CONFIG REQUIRED)
+set(protobuf_MODULE_COMPATIBLE ON CACHE BOOL "")
+find_package(Protobuf CONFIG REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/src/bridge/ProtobufMessages.proto")
 SET_SOURCE_FILES_PROPERTIES(${PROTO_SRC} ${PROTO_INCL} PROPERTIES GENERATED TRUE)
 
@@ -99,6 +99,7 @@ add_custom_command(
 )
 
 # Copy libprotobuf dll to output folder
+# NOTE: This only works with Release/RelWithDebInfo, because Debug uses libprotobufd.dll
 add_custom_command(
     TARGET ${PROJECT_NAME} 
     POST_BUILD

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "name": "slimevr-openvr-driver",
+    "version": "0.2.0",
+    "dependencies": [
+        "protobuf"
+    ]
+}


### PR DESCRIPTION
Have a minor change that fixes protobuf on my system, and a more major one of using vcpkg's manifest mode (as reccomended in their documentation). The latter means that dependencies from vcpkg are automatically grabbed when cmake configuration is done.

It occurs to me that perhaps the comment in the cmake file about installing protobuf is no longer necessary.

I've kept my changes as minimal as possible, by which I mean that I've not adjusted the other library dependencies to run through vcpkg, and I haven't adjusted how we call protobuf in our cmake script. If desirable, these are changes we can make in the future.