### PR TITLE
Fix missing break statement noticed by Funnbot in Discord.

### DIFF
--- a/src/TrackerDevice.cpp
+++ b/src/TrackerDevice.cpp
@@ -76,6 +76,7 @@ void SlimeVRDriver::TrackerDevice::StatusMessage(messages::TrackerStatus &status
     case messages::TrackerStatus_Status_DISCONNECTED:
         pose.deviceIsConnected = false;
         pose.poseIsValid = false;
+        break;
     default:
     case messages::TrackerStatus_Status_ERROR:
     case messages::TrackerStatus_Status_BUSY:


### PR DESCRIPTION
This bug would cause the tracker to not actually be disconnected from steamvr.