### PR TITLE
Use the x64-windows-static-md triplet

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,7 +13,7 @@ jobs:
         os: [windows-latest] # Others are disabled, this only targets Windows
         include:
           - os: windows-latest
-            triplet: x64-windows
+            triplet: x64-windows-static-md
     env:
       # Indicates the CMake build directory where project files and binaries are being produced.
       CMAKE_BUILD_DIR: ${{ github.workspace }}/build
@@ -61,7 +61,7 @@ jobs:
       run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
     
     - name: Configure CMake
-      run: cmake -S "${{github.workspace}}" -B "${{env.CMAKE_BUILD_DIR}}"
+      run: cmake -S "${{github.workspace}}" -B "${{env.CMAKE_BUILD_DIR}}" -DVCPKG_TARGET_TRIPLET=${{matrix.triplet}}
       
     - name: Build
       run: cmake --build "${{env.CMAKE_BUILD_DIR}}" --config Release --target ALL_BUILD -j 6 --

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,13 +97,3 @@ add_custom_command(
     $<TARGET_FILE:${PROJECT_NAME}>
     $<TARGET_FILE_DIR:${PROJECT_NAME}>/driver/${DRIVER_NAME}/bin/${PLATFORM_NAME}${PROCESSOR_ARCH}/driver_${DRIVER_NAME}$<TARGET_FILE_SUFFIX:${PROJECT_NAME}>
 )
-
-# Copy libprotobuf dll to output folder
-# NOTE: This only works with Release/RelWithDebInfo, because Debug uses libprotobufd.dll
-add_custom_command(
-    TARGET ${PROJECT_NAME} 
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy 
-    $<TARGET_FILE_DIR:${PROJECT_NAME}>/libprotobuf.dll
-    $<TARGET_FILE_DIR:${PROJECT_NAME}>/driver/${DRIVER_NAME}/bin/${PLATFORM_NAME}${PROCESSOR_ARCH}/libprotobuf.dll
-)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.0.0)
 
+if (NOT DEFINED VCPKG_TARGET_TRIPLET)
+    if(WIN32)
+        set(VCPKG_TARGET_TRIPLET "x64-windows-static-md")
+    endif()
+endif()
+
 # If the toolchain is already defined, do not attempt to find it
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
     # If the VCPKG_ROOT environment variable is not defined, try to automatically define it from AppData/home


### PR DESCRIPTION
Motivation: apparently there are compatibility hazards if we use dynamic linking for protobuf, and people are running into this with k2vr.

So far, this PR makes the minimal changes so that CI does the correct thing. Developers should also have it automatically do the right thing (after a clean reconfigure?) due to the section I added to the top of CMakeLists.txt