### PR TITLE
Check flatpak runtime dir first on Linux

### DIFF
--- a/src/bridge/bridge-unix-sockets.cpp
+++ b/src/bridge/bridge-unix-sockets.cpp
@@ -35,6 +35,7 @@
 #define TMP_DIR "/tmp"
 #define XDG_DATA_DIR_DEFAULT ".local/share"
 #define SLIMEVR_DATA_DIR "slimevr"
+#define SLIMEVR_FLATPAK_RUNTIME_DIR "app/dev.slimevr.SlimeVR"
 #define SOCKET_NAME "SlimeVRDriver"
 
 namespace fs = std::filesystem;
@@ -162,7 +163,11 @@ BridgeStatus runBridgeFrame(SlimeVRDriver::VRDriver& driver) {
             // TODO: do this once in the constructor or something
             if(const char* ptr = std::getenv("XDG_RUNTIME_DIR")) {
                 const fs::path xdg_runtime = ptr;
-                socket = (xdg_runtime / SOCKET_NAME);
+                // check flatpak dir first, then root runtime dir
+                socket = (xdg_runtime / SLIMEVR_FLATPAK_RUNTIME_DIR / SOCKET_NAME);
+                if(!fs::exists(socket)) {
+                    socket = (xdg_runtime / SOCKET_NAME);
+                }
             }
             if(!fs::exists(socket)) {
                 socket = (fs::path(TMP_DIR) / SOCKET_NAME);


### PR DESCRIPTION
This change would allow SlimeVR to work when the server is running inside a flatpak.

This change has SlimeVR look for sockets in `$XDG_RUNTIME_DIR/app/dev.slimevr.SlimeVR` before other locations, since this is the only place inside `$XDG_RUNTIME_DIR` SlimeVR-Server can write to when running inside a flatpak.

If Steam is also running inside a flatpak, we can gain access to this folder on the host by running `flatpak override --user --filesystem=xdg-run/app/dev.slimevr.SlimeVR:create com.valvesoftware.Steam`.