### PR TITLE
Upload release as draft

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -84,10 +84,12 @@ jobs:
       working-directory: ${{env.CMAKE_BUILD_DIR}}/${{ matrix.release_dir }}/driver
       run: cmake -E tar "cf" "${{env.CMAKE_BUILD_DIR}}/slimevr-openvr-driver-${{ matrix.triplet }}.zip" --format=zip -- ${{env.CMAKE_BUILD_DIR}}/${{ matrix.release_dir }}/driver/slimevr
 
-    - name: Release
+    - name: Upload to draft release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
+        draft: true
+        generate_release_notes: true
         files: "${{env.CMAKE_BUILD_DIR}}/slimevr-openvr-driver-${{ matrix.triplet }}.zip"
   
   test:


### PR DESCRIPTION
We do this workflow for server releases, we should probably upload as a draft first for the driver as well