### PR TITLE
Added optional Velocity fields to Protobuf Position Message (Natural Locomotion Support)

### DIFF
--- a/src/TrackerDevice.cpp
+++ b/src/TrackerDevice.cpp
@@ -55,6 +55,15 @@ void SlimeVRDriver::TrackerDevice::PositionMessage(messages::Position &position)
     pose.qRotation.y = position.qy();
     pose.qRotation.z = position.qz();
 
+    if (position.has_vx()) { 
+        pose.vecVelocity[0] = position.vx(); 
+        pose.vecVelocity[1] = position.vy(); 
+        pose.vecVelocity[2] = position.vz(); 
+    }
+    else { // If velocity isn't being sent, don't keep stale values 
+        pose.vecVelocity[0] = 0.0f; pose.vecVelocity[1] = 0.0f; pose.vecVelocity[2] = 0.0f; 
+    }
+
     auto current_universe = GetDriver()->GetCurrentUniverse();
     if (current_universe.has_value()) {
         auto trans = current_universe.value();

--- a/src/bridge/ProtobufMessages.proto
+++ b/src/bridge/ProtobufMessages.proto
@@ -74,6 +74,9 @@ message Position {
         FULL = 3;
     }
     optional DataSource data_source = 9;
+    optional float vx = 10; 
+    optional float vy = 11; 
+    optional float vz = 12;
 }
 
 message UserAction {


### PR DESCRIPTION
Natural Locomotion (NaLo) has been able to enumerate and identify SlimeVR trackers via SteamVR for quite some time.
The primary reason SlimeVR trackers were not usable by NaLo was that the OpenVR driver explicitly reported zero velocity and acceleration for all trackers.

~~Newly added code derives velocity and acceleration from per-frame positional deltas and reports these values to SteamVR using the expected OpenVR kinematic fields.~~
Switched to server-side calculation, the new driver-side code adds a new definition to ProtobufMessages (Velocity Vector3: vx, vy, vz), and sends this data to SteamVR Virtual Trackers in the same package with Position and Rotation. This adds new functionality while keeping the code architecture and code style the same. Velocity is optional, and if not received, will always report 0 to SteamVR Trackers, basically, falling back to the current behaviour.

~~This change does not affect positional tracking, as the derived kinematic data is only consumed by SteamVR addons and is not used for pose estimation.~~
This does affect SteamVR's pose prediction. ~~Cannot be fixed by design. Proposed solution: Make feature toggleable and customizable to allow users decide how they want to use this feature.~~
I managed to locate the perfect source of positional data on the server and provide velocity updates with a matching polling rate. This has significantly reduced the jitter that was previously caused by overprediction. Currently, the jitter is either small or non-existent.
However, the feature will still be toggleable and allow for some additional customization to improve compatibility.

Doing so allows NaLo to receive the data that was missing, while the only dependency is the position data we receive from the tracker. Because the implementation relies solely on positional data already provided by the tracker, the change is cross-hardware compatible and does not depend on IMU-specific data.

The additional computation is trivial for modern CPUs and is not expected to introduce measurable performance or latency impact. Observed per-frame processing time is on the order of a few milliseconds.

~~The implementation includes velocity clamping to suppress unrealistic spikes (e.g., sustained speeds above 6 m/s), as well as a delta-time guard to handle stale or invalid frame intervals and avoid division-by-zero or incorrect updates.~~
Removed due to server-side data being more stable and filtered.

Directional movement (e.g., strafing with the head facing forward) is handled correctly by SteamVR based on the reported kinematic data, requiring no additional logic in the OpenVR driver.

Related to the issue:
https://github.com/SlimeVR/SlimeVR-Server/issues/25