### PR TITLE
Add 'compatibility mode' option to use VIVE tracker input profile

### DIFF
--- a/driver/slimevr/resources/settings/default.vrsettings
+++ b/driver/slimevr/resources/settings/default.vrsettings
@@ -1,0 +1,5 @@
+{
+    "driver_slimevr": {
+        "emulateVives": false
+    }
+}

--- a/driver/slimevr/resources/settings/settingsschema.vrsettings
+++ b/driver/slimevr/resources/settings/settingsschema.vrsettings
@@ -1,0 +1,17 @@
+[
+    {
+        "title": "SlimeVR",
+        "show_without_hmd": true,
+        "values": [
+            {
+                "name": "/settings/driver_slimevr/emulateVives",
+                "control": "toggle",
+                "label": "Compatibility Mode",
+                "on_label": "Enabled",
+                "off_label": "Disabled",
+                "advanced_only": true,
+                "requires_restart": true
+            }
+        ]
+    }
+]

--- a/src/TrackerDevice.cpp
+++ b/src/TrackerDevice.cpp
@@ -162,7 +162,9 @@ vr::EVRInitError SlimeVRDriver::TrackerDevice::Activate(uint32_t unObjectId) {
 
     // Some device properties will be derived at runtime by SteamVR
     // using the profile, such as the device class and controller type
-    GetDriver()->GetProperties()->SetStringProperty(props, vr::Prop_InputProfilePath_String, "{slimevr}/input/slimevr_tracker_profile.json");
+    bool emulate_vives = vr::VRSettings()->GetBool("driver_slimevr", "emulateVives");
+    std::string input_profile_path = emulate_vives ? "{htc}/input/vive_tracker_profile.json" : "{slimevr}/input/slimevr_tracker_profile.json";
+    GetDriver()->GetProperties()->SetStringProperty(props, vr::Prop_InputProfilePath_String, input_profile_path.c_str());
 
     // Doesn't apply until restart of SteamVR
     auto role = GetViveRole(tracker_role_);


### PR DESCRIPTION
SteamVR only exposes trackers through XR_HTCX_vive_tracker_interaction when their Prop_ControllerType_String is `vive_tracker_[role]`, but if we set that in our input profile unconditionally, it will bring back the 'no bindings' popup on Vive Tracker (Chest) for everyone, so just add an option gated behind 'Advanced Settings' to use the VIVE tracker profile.