### PR TITLE
Delay pose request thread loop and SendVersion call until SteamVR init is done

### DIFF
--- a/src/VRDriver.cpp
+++ b/src/VRDriver.cpp
@@ -26,19 +26,25 @@ vr::EVRInitError SlimeVRDriver::VRDriver::Init(vr::IVRDriverContext* pDriverCont
 
     bridge_ = std::make_shared<BridgeClient>(
         std::static_pointer_cast<Logger>(std::make_shared<VRLogger>("Bridge")),
-        std::bind(&SlimeVRDriver::VRDriver::OnBridgeMessage, this, std::placeholders::_1));
+        std::bind(&SlimeVRDriver::VRDriver::OnBridgeMessage, this, std::placeholders::_1),
+        std::bind(&SlimeVRDriver::VRDriver::OnBridgeConnect, this));
     bridge_->Start();
 
-    exiting_pose_request_thread_ = false;
     pose_request_thread_ = std::make_unique<std::thread>(&SlimeVRDriver::VRDriver::RunPoseRequestThread, this);
 
     return vr::VRInitError_None;
 }
 
 void SlimeVRDriver::VRDriver::Cleanup() {
-    exiting_pose_request_thread_ = true;
+    exiting_.store(true);
+    // Wake up all threads waiting on init, if SteamVR exits before an HMD is connected
+    steamvr_init_guard_.store(true);
+    steamvr_init_guard_.notify_all();
+
+    logger_->Log("Waiting for pose request thread to exit");
     pose_request_thread_->join();
     pose_request_thread_.reset();
+    logger_->Log("Stopping bridge");
     bridge_->Stop();
 }
 
@@ -92,7 +98,12 @@ TrackerRole SlimeVRDriver::VRDriver::GetRoleForDevice(vr::TrackedDeviceIndex_t i
 void SlimeVRDriver::VRDriver::RunPoseRequestThread() {
     std::array<DeviceData, vr::k_unMaxTrackedDeviceCount> devices{};
     logger_->Log("Pose request thread started");
-    while (!exiting_pose_request_thread_) {
+    steamvr_init_guard_.wait(false);
+    // If SteamVR exited before initialisation completed, we'll just
+    // skip past the loop body on the first iteration anyway
+
+    logger_->Log("Entering pose request loop");
+    while (!exiting_) {
         if (!bridge_->IsConnected()) {
             // If bridge not connected, assume we need to resend device add messages
             for (auto& device : devices) {
@@ -293,15 +304,48 @@ void SlimeVRDriver::VRDriver::RunPoseRequestThread() {
 
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
-    logger_->Log("Pose request thread exited");
+    logger_->Log("Pose request thread exiting");
 }
 
 void SlimeVRDriver::VRDriver::RunFrame() {
     // Collect events
     vr::VREvent_t event;
     std::vector<vr::VREvent_t> events;
+    auto* properties = vr::VRProperties();
+
     while (vr::VRServerDriverHost()->PollNextEvent(&event, sizeof(event))) {
         events.push_back(event);
+
+        if (steamvr_init_guard_) {
+            // We already signaled init was done.
+            continue;
+        }
+
+        auto hmd_device_class = properties->GetInt32Property(properties->TrackedDeviceToPropertyContainer(vr::k_unTrackedDeviceIndex_Hmd), vr::Prop_DeviceClass_Int32);
+        bool signal_steamvr_init_done = false;
+        // this is the signal SteamVR uses to start up the systemui as of 2.17.1
+        switch (event.eventType) {
+        case vr::VREvent_TrackedDeviceActivated: {
+            if (event.trackedDeviceIndex != vr::k_unTrackedDeviceIndex_Hmd)
+                break;
+            if (hmd_device_class != vr::TrackedDeviceClass_Invalid) {
+                logger_->Log("Received TrackedDeviceActivated for HMD and its device class is not Invalid");
+                signal_steamvr_init_done = true;
+            }
+            break;
+        }
+        default:
+            signal_steamvr_init_done = hmd_device_class != vr::TrackedDeviceClass_Invalid;
+            if (signal_steamvr_init_done) {
+                logger_->Log("Received an event and device class for HMD is not Invalid");
+            }
+            break;
+        }
+        if (signal_steamvr_init_done) {
+            logger_->Log("Signaling that SteamVR is done initialising");
+            steamvr_init_guard_.store(true);
+            steamvr_init_guard_.notify_all();
+        }
     }
     openvr_events_ = std::move(events);
 
@@ -319,6 +363,20 @@ void SlimeVRDriver::VRDriver::RunFrame() {
     }
 }
 
+void SlimeVRDriver::VRDriver::OnBridgeConnect() {
+    std::thread t{ [this]() {
+        steamvr_init_guard_.wait(false);
+        // We woke up because SteamVR exited before initialisation.
+        if (exiting_) {
+            logger_->Log("Exiting OnBridgeConnect early");
+            return;
+        }
+
+        logger_->Log("Sending version message");
+        bridge_->SendVersion();
+    } };
+    t.detach();
+}
 void SlimeVRDriver::VRDriver::OnBridgeMessage(const messages::ProtobufMessage& message) {
     std::lock_guard<std::mutex> lock(devices_mutex_);
     if (message.has_tracker_added()) {

--- a/src/VRDriver.hpp
+++ b/src/VRDriver.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #define NOMINMAX
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -42,12 +44,18 @@ public:
 
     virtual std::optional<UniverseTranslation> GetCurrentUniverse() override;
 
+    void OnBridgeConnect();
     void OnBridgeMessage(const messages::ProtobufMessage& message);
     void RunPoseRequestThread();
 
 private:
+    // set to true if initialisation is done, or we're exiting
+    // if we're exiting, this will be true AND exiting_ will be true
+    std::atomic<bool> steamvr_init_guard_ = false;
+
+    std::atomic<bool> exiting_ = false;
+
     std::unique_ptr<std::thread> pose_request_thread_ = nullptr;
-    std::atomic<bool> exiting_pose_request_thread_ = false;
 
     TrackerRole GetRoleForDevice(vr::TrackedDeviceIndex_t index) const;
 

--- a/src/bridge/BridgeClient.cpp
+++ b/src/bridge/BridgeClient.cpp
@@ -40,7 +40,7 @@ void BridgeClient::CreateConnection() {
         logger_->Log("[{}] connected", path);
         connected_ = true;
         last_error_ = std::nullopt;
-        SendVersion();
+        OnConnect();
     });
     connection_handle_->on<uvw::end_event>([this, path](const uvw::end_event&, uvw::pipe_handle&) {
         logger_->Log("[{}] disconnected", path);

--- a/src/bridge/BridgeClient.hpp
+++ b/src/bridge/BridgeClient.hpp
@@ -45,13 +45,13 @@
 class BridgeClient : public BridgeTransport {
 public:
     using BridgeTransport::BridgeTransport;
+    void SendVersion();
 
 private:
     void CreateConnection() override;
     void ResetConnection() override;
     void CloseConnectionHandles() override;
     void Reconnect();
-    void SendVersion();
 
     std::optional<std::string> last_error_;
     std::optional<std::string> last_path_;

--- a/src/bridge/BridgeTransport.cpp
+++ b/src/bridge/BridgeTransport.cpp
@@ -69,6 +69,10 @@ void BridgeTransport::ResetBuffers() {
     send_buf_.Clear();
 }
 
+void BridgeTransport::OnConnect() {
+    if (connect_callback_)
+        (*connect_callback_)();
+}
 void BridgeTransport::OnRecv(const uvw::data_event& event) {
     if (!recv_buf_.Push(event.data.get(), event.length)) {
         logger_->Log("recv_buf_.Push({}) failed", event.length);

--- a/src/bridge/BridgeTransport.hpp
+++ b/src/bridge/BridgeTransport.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include <stdint.h>
 #include <thread>
 #include <uvw.hpp>
@@ -58,11 +59,12 @@ namespace fs = std::filesystem;
  */
 class BridgeTransport {
 public:
-    BridgeTransport(std::shared_ptr<Logger> logger, std::function<void(const messages::ProtobufMessage&)> on_message_received)
+    BridgeTransport(std::shared_ptr<Logger> logger, std::function<void(const messages::ProtobufMessage&)> on_message_received, std::optional<std::function<void()>> on_connect = std::nullopt)
         : logger_(logger)
-        , message_callback_(on_message_received)
         , send_buf_(VRBRIDGE_BUFFERS_SIZE)
-        , recv_buf_(VRBRIDGE_BUFFERS_SIZE) { }
+        , recv_buf_(VRBRIDGE_BUFFERS_SIZE)
+        , connect_callback_(on_connect)
+        , message_callback_(on_message_received) { }
 
     ~BridgeTransport() {
         Stop();
@@ -112,6 +114,7 @@ protected:
     virtual void ResetConnection() = 0;
     virtual void CloseConnectionHandles() = 0;
     void ResetBuffers();
+    void OnConnect();
     void OnRecv(const uvw::data_event& event);
     auto GetLoop() {
         return loop_;
@@ -161,5 +164,6 @@ private:
     std::shared_ptr<uvw::async_handle> write_signal_handle_ = nullptr;
     std::unique_ptr<std::thread> thread_ = nullptr;
     std::shared_ptr<uvw::loop> loop_ = nullptr;
+    const std::optional<std::function<void()>> connect_callback_;
     const std::function<void(const messages::ProtobufMessage&)> message_callback_;
 };


### PR DESCRIPTION
This may fix cases of the bindings provider failing to start, due to it being spawned before the HMD device has been activated, such as SlimeVR/SlimeVR-Server#1898.